### PR TITLE
feat: improve config loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ async def main_async(config: Config) -> None:
 
 def main(config_path: Optional[str] = None) -> None:
     """Synchronously loads configuration and starts the event loop."""
-    config = load_config(config_path)
+    config, _ = load_config(config_path)
     configure_logging(config)
     try:
         asyncio.run(main_async(config))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration to ensure package import paths."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+"""Tests for configuration loading and path resolution."""
+
+from pathlib import Path
+
+import yaml
+
+from multirec.config.config import Config, load_config
+
+
+def test_load_config_uses_project_file(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("concurrency_limit: 7\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config, path = load_config()
+
+    assert path == cfg
+    assert config.concurrency_limit == 7
+
+
+def test_load_config_creates_default(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config, path = load_config()
+
+    expected = tmp_path / ".multirec" / "config.yaml"
+    assert path == expected
+    assert path.exists()
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    assert data == Config().model_dump(mode="json")
+    assert config == Config()
+


### PR DESCRIPTION
## Summary
- search for config file in parameter path, project config, then fallback to `~/.multirec/config.yaml`
- create default config file when none exists and log the loaded path
- return both the config object and path
- add tests for config resolution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6244c7d30833280b3c3791cc4b74d