### PR TITLE
Add robust recording pipeline with metadata and fallback

### DIFF
--- a/multirec/recorder/recorder.py
+++ b/multirec/recorder/recorder.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import json
+import re
 import shutil
 import tempfile
 from dataclasses import dataclass, field
@@ -27,6 +29,7 @@ class RecordingResult:
     """Represents the result of a recording session."""
     success: bool
     file_path: Optional[Path] = None
+    metadata_path: Optional[Path] = None
     error: Optional[str] = None
     start_time: dt.datetime = field(default_factory=dt.datetime.utcnow)
     end_time: Optional[dt.datetime] = None
@@ -42,6 +45,7 @@ class StreamRecorder:
         segment_duration: int,
         quality: str = "best",
         on_update: Optional[Callable[[str], None]] = None,
+        crf: int = 23,
     ) -> None:
         self.channel_url = channel_url
         self.output_dir = output_dir
@@ -49,19 +53,21 @@ class StreamRecorder:
         self.quality = quality
         self.on_update = on_update
         self._cancel_event = asyncio.Event()
+        self.crf = crf
 
     def cancel(self) -> None:
         """Requests cancellation of the recording."""
         self._cancel_event.set()
 
     async def record(self) -> RecordingResult:
-        """Executes the recording asynchronously."""
+        """Executes the recording asynchronously with remux/transcode pipeline."""
+
         start_time = dt.datetime.utcnow()
         temp_dir = Path(tempfile.mkdtemp(prefix="multirec_"))
         temp_file = temp_dir / "download.ts"
         output_file = self.output_dir / f"{start_time:%Y%m%dT%H%M%S}.mp4"
+        metadata_path = output_file.with_suffix(".json")
 
-        # Build the yt-dlp command for HLS download
         yt_cmd = [
             "yt-dlp",
             self.channel_url,
@@ -76,15 +82,17 @@ class StreamRecorder:
             str(temp_file),
         ]
 
-        # Spawn yt-dlp process
         process = await asyncio.create_subprocess_exec(
             *yt_cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
 
+        progress_re = re.compile(
+            r"\[download\]\s+(?P<pct>[0-9.]+)%.*?of\s+~?(?P<size>[0-9.]+)(?P<unit>[KMG]iB).*?ETA\s+(?P<eta>[0-9:\.]+)"
+        )
+
         try:
-            # Read lines asynchronously and optionally notify
             while True:
                 if self._cancel_event.is_set():
                     process.terminate()
@@ -93,8 +101,18 @@ class StreamRecorder:
                 line = await process.stdout.readline()
                 if not line:
                     break
-                if self.on_update:
-                    self.on_update(line.decode(errors="ignore").strip())
+                text = line.decode(errors="ignore").strip()
+                if self.on_update and text:
+                    m = progress_re.search(text)
+                    if m:
+                        size = float(m.group("size"))
+                        unit = m.group("unit")
+                        factor = {"KiB": 1/1024, "MiB": 1, "GiB": 1024}.get(unit, 1)
+                        mb = size * factor
+                        msg = f"eta={m.group('eta')} total={mb:.1f}MB pct={m.group('pct')}%"
+                        self.on_update(msg)
+                    else:
+                        self.on_update(text)
             rc = await process.wait()
             if rc != 0:
                 return RecordingResult(success=False, error=f"yt-dlp exited with {rc}", start_time=start_time)
@@ -103,7 +121,6 @@ class StreamRecorder:
             await process.wait()
             return RecordingResult(success=False, error=str(e), start_time=start_time)
 
-        # Once download is complete, remux using ffmpeg
         ff_cmd = [
             "ffmpeg",
             "-y",
@@ -121,14 +138,64 @@ class StreamRecorder:
             stderr=asyncio.subprocess.STDOUT,
         )
         await remux_proc.communicate()
-        rc2 = remux_proc.returncode
-        if rc2 != 0:
-            return RecordingResult(success=False, error=f"ffmpeg exited with {rc2}", start_time=start_time)
 
-        # Clean up temporary file
+        if remux_proc.returncode != 0:
+            trans_cmd = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(temp_file),
+                "-c:v",
+                "libx264",
+                "-crf",
+                str(self.crf),
+                "-c:a",
+                "aac",
+                "-movflags",
+                "+faststart",
+                str(output_file),
+            ]
+            trans_proc = await asyncio.create_subprocess_exec(
+                *trans_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            await trans_proc.communicate()
+            if trans_proc.returncode != 0:
+                try:
+                    shutil.rmtree(temp_dir)
+                except Exception:
+                    pass
+                return RecordingResult(
+                    success=False,
+                    error=f"ffmpeg transcode exited with {trans_proc.returncode}",
+                    start_time=start_time,
+                )
+
+        end_time = dt.datetime.utcnow()
+        metadata = {
+            "channel_url": self.channel_url,
+            "quality": self.quality,
+            "segment_duration": self.segment_duration,
+            "start_time": start_time.isoformat(),
+            "end_time": end_time.isoformat(),
+            "output": str(output_file),
+        }
+        try:
+            with open(metadata_path, "w", encoding="utf-8") as fh:
+                json.dump(metadata, fh, indent=2)
+        except Exception:
+            metadata_path = None
+
         try:
             shutil.rmtree(temp_dir)
         except Exception:
             pass
 
-        return RecordingResult(success=True, file_path=output_file, start_time=start_time, end_time=dt.datetime.utcnow())
+        return RecordingResult(
+            success=True,
+            file_path=output_file,
+            metadata_path=metadata_path,
+            start_time=start_time,
+            end_time=end_time,
+        )


### PR DESCRIPTION
## Summary
- support yt-dlp based HLS recording with progress parsing
- remux to MP4 then fallback to libx264/aac transcode if needed
- emit JSON metadata alongside recordings
- scheduler now loads recorder dynamically for easier testing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6232d78dc8332b8124576ee3341e7